### PR TITLE
rm/sparse-index-integration-v1.1

### DIFF
--- a/builtin/reset.c
+++ b/builtin/reset.c
@@ -174,88 +174,6 @@ static void update_index_from_diff(struct diff_queue_struct *q,
 	}
 }
 
-static int pathspec_needs_expanded_index(const struct pathspec *pathspec)
-{
-	unsigned int i, pos;
-	int res = 0;
-	char *skip_worktree_seen = NULL;
-
-	/*
-	 * When using a magic pathspec, assume for the sake of simplicity that
-	 * the index needs to be expanded to match all matchable files.
-	 */
-	if (pathspec->magic)
-		return 1;
-
-	for (i = 0; i < pathspec->nr; i++) {
-		struct pathspec_item item = pathspec->items[i];
-
-		/*
-		 * If the pathspec item has a wildcard, the index should be expanded
-		 * if the pathspec has the possibility of matching a subset of entries inside
-		 * of a sparse directory (but not the entire directory).
-		 *
-		 * If the pathspec item is a literal path, the index only needs to be expanded
-		 * if a) the pathspec isn't in the sparse checkout cone (to make sure we don't
-		 * expand for in-cone files) and b) it doesn't match any sparse directories
-		 * (since we can reset whole sparse directories without expanding them).
-		 */
-		if (item.nowildcard_len < item.len) {
-			/*
-			 * Special case: if the pattern is a path inside the cone
-			 * followed by only wildcards, the pattern cannot match
-			 * partial sparse directories, so we know we don't need to
-			 * expand the index.
-			 *
-			 * Examples:
-			 * - in-cone/foo***: doesn't need expanded index
-			 * - not-in-cone/bar*: may need expanded index
-			 * - **.c: may need expanded index
-			 */
-			if (strspn(item.original + item.nowildcard_len, "*") == item.len - item.nowildcard_len &&
-			    path_in_cone_mode_sparse_checkout(item.original, &the_index))
-				continue;
-
-			for (pos = 0; pos < active_nr; pos++) {
-				struct cache_entry *ce = active_cache[pos];
-
-				if (!S_ISSPARSEDIR(ce->ce_mode))
-					continue;
-
-				/*
-				 * If the pre-wildcard length is longer than the sparse
-				 * directory name and the sparse directory is the first
-				 * component of the pathspec, need to expand the index.
-				 */
-				if (item.nowildcard_len > ce_namelen(ce) &&
-				    !strncmp(item.original, ce->name, ce_namelen(ce))) {
-					res = 1;
-					break;
-				}
-
-				/*
-				 * If the pre-wildcard length is shorter than the sparse
-				 * directory and the pathspec does not match the whole
-				 * directory, need to expand the index.
-				 */
-				if (!strncmp(item.original, ce->name, item.nowildcard_len) &&
-				    wildmatch(item.original, ce->name, 0)) {
-					res = 1;
-					break;
-				}
-			}
-		} else if (!path_in_cone_mode_sparse_checkout(item.original, &the_index) &&
-			   !matches_skip_worktree(pathspec, i, &skip_worktree_seen))
-			res = 1;
-
-		if (res > 0)
-			break;
-	}
-
-	free(skip_worktree_seen);
-	return res;
-}
-
 static int read_from_tree(const struct pathspec *pathspec,
 			  struct object_id *tree_oid,
 			  int intent_to_add)
@@ -273,7 +191,7 @@ static int read_from_tree(const struct pathspec *pathspec,
 	opt.change = diff_change;
 	opt.add_remove = diff_addremove;
 
-	if (pathspec->nr && the_index.sparse_index && pathspec_needs_expanded_index(pathspec))
+	if (pathspec->nr && the_index.sparse_index && pathspec_needs_expanded_index(&the_index, pathspec))
 		ensure_full_index(&the_index);
 
 	if (do_diff_cache(tree_oid, &opt))

--- a/builtin/rm.c
+++ b/builtin/rm.c
@@ -296,8 +296,9 @@ int cmd_rm(int argc, const char **argv, const char *prefix)
 
 	seen = xcalloc(pathspec.nr, 1);
 
-	/* TODO: audit for interaction with sparse-index. */
-	ensure_full_index(&the_index);
+	if (pathspec_needs_expanded_index(&the_index, &pathspec))
+		ensure_full_index(&the_index);
+
 	for (i = 0; i < active_nr; i++) {
 		const struct cache_entry *ce = active_cache[i];
 

--- a/builtin/rm.c
+++ b/builtin/rm.c
@@ -262,6 +262,10 @@ int cmd_rm(int argc, const char **argv, const char *prefix)
 	char *seen;
 
 	git_config(git_default_config, NULL);
+	if (the_repository->gitdir) {
+		prepare_repo_settings(the_repository);
+		the_repository->settings.command_requires_full_index = 0;
+	}
 
 	argc = parse_options(argc, argv, prefix, builtin_rm_options,
 			     builtin_rm_usage, 0);

--- a/pathspec.c
+++ b/pathspec.c
@@ -759,3 +759,92 @@ int match_pathspec_attrs(struct index_state *istate,
 
 	return 1;
 }
+
+int pathspec_needs_expanded_index(struct index_state *istate,
+				  const struct pathspec *pathspec)
+{
+	unsigned int i, pos;
+	int res = 0;
+	char *skip_worktree_seen = NULL;
+
+	/*
+	 * If index is not sparse, no index expansion is needed.
+	 */
+	if (!istate->sparse_index)
+		return 0;
+
+	/*
+	 * When using a magic pathspec, assume for the sake of simplicity that
+	 * the index needs to be expanded to match all matchable files.
+	 */
+	if (pathspec->magic)
+		return 1;
+
+	for (i = 0; i < pathspec->nr; i++) {
+		struct pathspec_item item = pathspec->items[i];
+
+		/*
+		 * If the pathspec item has a wildcard, the index should be expanded
+		 * if the pathspec has the possibility of matching a subset of entries inside
+		 * of a sparse directory (but not the entire directory).
+		 *
+		 * If the pathspec item is a literal path, the index only needs to be expanded
+		 * if a) the pathspec isn't in the sparse checkout cone (to make sure we don't
+		 * expand for in-cone files) and b) it doesn't match any sparse directories
+		 * (since we can reset whole sparse directories without expanding them).
+		 */
+		if (item.nowildcard_len < item.len) {
+			/*
+			 * Special case: if the pattern is a path inside the cone
+			 * followed by only wildcards, the pattern cannot match
+			 * partial sparse directories, so we know we don't need to
+			 * expand the index.
+			 *
+			 * Examples:
+			 * - in-cone/foo***: doesn't need expanded index
+			 * - not-in-cone/bar*: may need expanded index
+			 * - **.c: may need expanded index
+			 */
+			if (strspn(item.original + item.nowildcard_len, "*") == item.len - item.nowildcard_len &&
+			    path_in_cone_mode_sparse_checkout(item.original, istate))
+				continue;
+
+			for (pos = 0; pos < istate->cache_nr; pos++) {
+				struct cache_entry *ce = istate->cache[pos];
+
+				if (!S_ISSPARSEDIR(ce->ce_mode))
+					continue;
+
+				/*
+				 * If the pre-wildcard length is longer than the sparse
+				 * directory name and the sparse directory is the first
+				 * component of the pathspec, need to expand the index.
+				 */
+				if (item.nowildcard_len > ce_namelen(ce) &&
+				    !strncmp(item.original, ce->name, ce_namelen(ce))) {
+					res = 1;
+					break;
+				}
+
+				/*
+				 * If the pre-wildcard length is shorter than the sparse
+				 * directory and the pathspec does not match the whole
+				 * directory, need to expand the index.
+				 */
+				if (!strncmp(item.original, ce->name, item.nowildcard_len) &&
+				    wildmatch(item.original, ce->name, 0)) {
+					res = 1;
+					break;
+				}
+			}
+		} else if (!path_in_cone_mode_sparse_checkout(item.original, istate) &&
+			   !matches_skip_worktree(pathspec, i, &skip_worktree_seen))
+			res = 1;
+
+		if (res > 0)
+			break;
+	}
+
+	free(skip_worktree_seen);
+	return res;
+}

--- a/pathspec.h
+++ b/pathspec.h
@@ -171,4 +171,16 @@ int match_pathspec_attrs(struct index_state *istate,
 			 const char *name, int namelen,
 			 const struct pathspec_item *item);
 
+/*
+ * Determine whether a pathspec will match only entire index entries (non-sparse
+ * files and/or entire sparse directories). If the pathspec has the potential to
+ * match partial contents of a sparse directory, return 1 to indicate the index
+ * should be expanded to match the  appropriate index entries.
+ *
+ * For the sake of simplicity, always return 1 if using a more complex "magic"
+ * pathspec.
+ */
+int pathspec_needs_expanded_index(struct index_state *istate,
+				  const struct pathspec *pathspec);
+
 #endif /* PATHSPEC_H */

--- a/t/perf/p2000-sparse-operations.sh
+++ b/t/perf/p2000-sparse-operations.sh
@@ -123,5 +123,6 @@ test_perf_on_all git blame $SPARSE_CONE/f3/a
 test_perf_on_all git read-tree -mu HEAD
 test_perf_on_all git checkout-index -f --all
 test_perf_on_all git update-index --add --remove $SPARSE_CONE/a
+test_perf_on_all git rm -f $SPARSE_CONE/a
 
 test_done

--- a/t/t1092-sparse-checkout-compatibility.sh
+++ b/t/t1092-sparse-checkout-compatibility.sh
@@ -1853,4 +1853,75 @@ test_expect_success 'mv directory from out-of-cone to in-cone' '
 	grep -e "H deep/0/1" actual
 '
 
+test_expect_success 'rm pathspec inside sparse definition' '
+	init_repos &&
+
+	test_all_match git rm deep/a &&
+	test_all_match git status --porcelain=v2 &&
+
+	# test wildcard
+	run_on_all git reset --hard &&
+	test_all_match git rm deep/* &&
+	test_all_match git status --porcelain=v2 &&
+
+	# test recursive rm
+	run_on_all git reset --hard &&
+	test_all_match git rm -r deep &&
+	test_all_match git status --porcelain=v2
+'
+
+test_expect_failure 'rm pathspec outside sparse definition' '
+	init_repos &&
+
+	for file in folder1/a folder1/0/1
+	do
+		test_sparse_match test_must_fail git rm $file &&
+		test_sparse_match test_must_fail git rm --cached $file &&
+		test_sparse_match git rm --sparse $file &&
+		test_sparse_match git status --porcelain=v2
+	done &&
+
+	cat >folder1-full <<-EOF &&
+	rm ${SQ}folder1/0/0/0${SQ}
+	rm ${SQ}folder1/0/1${SQ}
+	rm ${SQ}folder1/a${SQ}
+	EOF
+
+	cat >folder1-sparse <<-EOF &&
+	rm ${SQ}folder1/${SQ}
+	EOF
+
+	# test wildcard
+	run_on_sparse git reset --hard &&
+	run_on_sparse git sparse-checkout reapply &&
+	test_sparse_match test_must_fail git rm folder1/* &&
+	run_on_sparse git rm --sparse folder1/* &&
+	test_cmp folder1-full sparse-checkout-out &&
+	test_cmp folder1-sparse sparse-index-out &&
+	test_sparse_match git status --porcelain=v2 &&
+
+	# test recursive rm
+	run_on_sparse git reset --hard &&
+	run_on_sparse git sparse-checkout reapply &&
+	test_sparse_match test_must_fail git rm --sparse folder1 &&
+	run_on_sparse git rm --sparse -r folder1 &&
+	test_cmp folder1-full sparse-checkout-out &&
+	test_cmp folder1-sparse sparse-index-out &&
+	test_sparse_match git status --porcelain=v2
+'
+
+test_expect_failure 'sparse index is not expanded: rm' '
+	init_repos &&
+
+	ensure_not_expanded rm deep/a &&
+
+	# test in-cone wildcard
+	git -C sparse-index reset --hard &&
+	ensure_not_expanded rm deep/* &&
+
+	# test recursive rm
+	git -C sparse-index reset --hard &&
+	ensure_not_expanded rm -r deep
+'
+
 test_done

--- a/t/t1092-sparse-checkout-compatibility.sh
+++ b/t/t1092-sparse-checkout-compatibility.sh
@@ -1870,7 +1870,7 @@ test_expect_success 'rm pathspec inside sparse definition' '
 	test_all_match git status --porcelain=v2
 '
 
-test_expect_failure 'rm pathspec outside sparse definition' '
+test_expect_success 'rm pathspec outside sparse definition' '
 	init_repos &&
 
 	for file in folder1/a folder1/0/1
@@ -1910,7 +1910,7 @@ test_expect_failure 'rm pathspec outside sparse definition' '
 	test_sparse_match git status --porcelain=v2
 '
 
-test_expect_failure 'sparse index is not expanded: rm' '
+test_expect_success 'sparse index is not expanded: rm' '
 	init_repos &&
 
 	ensure_not_expanded rm deep/a &&

--- a/t/t1092-sparse-checkout-compatibility.sh
+++ b/t/t1092-sparse-checkout-compatibility.sh
@@ -912,7 +912,7 @@ test_expect_success 'read-tree --prefix' '
 	test_all_match git read-tree --prefix=deep/deeper1/deepest -u deepest &&
 	test_all_match git status --porcelain=v2 &&
 
-	test_all_match git rm -rf --sparse folder1/ &&
+	run_on_all git rm -rf --sparse folder1/ &&
 	test_all_match git read-tree --prefix=folder1/ -u update-folder1 &&
 	test_all_match git status --porcelain=v2 &&
 


### PR DESCRIPTION
```diff
1:  b5a0ac68dd ! 1:  a50c772d00 rm: integrate with sparse-index
    @@ Metadata
     Author: Shaoxuan Yuan <shaoxuan.yuan02@gmail.com>
     
      ## Commit message ##
    -    rm: integrate with sparse-index
    +    t1092: add tests for `git-rm`
     
    -    Turn off command_requires_full_index for `git-rm`.
    +    Add tests for `git-rm`, make sure it behaves as expected when
    +    <pathspec> is both inside or outside of sparse-checkout definition.
     
    -    Test `git-rm` when the target pathspec is in-cone and out-of-cone.
    -
    -    Ensure the sparse index is not expanded when operating inside of
    -    cone area.
    +    Also add ensure_not_expanded test to make sure `git-rm` does not
    +    accidentally expand the index when <pathspec> is within the
    +    sparse-checkout definition.
     
         Signed-off-by: Shaoxuan Yuan <shaoxuan.yuan02@gmail.com>
     
    - ## builtin/rm.c ##
    -@@ builtin/rm.c: int cmd_rm(int argc, const char **argv, const char *prefix)
    - 	char *seen;
    - 
    - 	git_config(git_default_config, NULL);
    -+	if (the_repository->gitdir) {
    -+		prepare_repo_settings(the_repository);
    -+		the_repository->settings.command_requires_full_index = 0;
    -+	}
    - 
    - 	argc = parse_options(argc, argv, prefix, builtin_rm_options,
    - 			     builtin_rm_usage, 0);
    -@@ builtin/rm.c: int cmd_rm(int argc, const char **argv, const char *prefix)
    - 
    - 	seen = xcalloc(pathspec.nr, 1);
    - 
    --	/* TODO: audit for interaction with sparse-index. */
    --	ensure_full_index(&the_index);
    - 	for (i = 0; i < active_nr; i++) {
    - 		const struct cache_entry *ce = active_cache[i];
    - 
    -
      ## t/t1092-sparse-checkout-compatibility.sh ##
     @@ t/t1092-sparse-checkout-compatibility.sh: test_expect_success 'mv directory from out-of-cone to in-cone' '
      	grep -e "H deep/0/1" actual
    @@ t/t1092-sparse-checkout-compatibility.sh: test_expect_success 'mv directory from
     +test_expect_success 'rm pathspec inside sparse definition' '
     +	init_repos &&
     +
    -+	for file in deep/a deep/deeper1/0/0/0 deep/deeper1/deepest/a
    -+	do
    -+		test_all_match git rm $file &&
    -+		test_all_match git status --porcelain=v2
    -+	done &&
    ++	test_all_match git rm deep/a &&
    ++	test_all_match git status --porcelain=v2 &&
     +
     +	# test wildcard
     +	run_on_all git reset --hard &&
    @@ t/t1092-sparse-checkout-compatibility.sh: test_expect_success 'mv directory from
     +test_expect_failure 'rm pathspec outside sparse definition' '
     +	init_repos &&
     +
    -+	for file in folder1/a folder1/0/1 folder1/0/0/0
    ++	for file in folder1/a folder1/0/1
     +	do
     +		test_sparse_match test_must_fail git rm $file &&
     +		test_sparse_match test_must_fail git rm --cached $file &&
    @@ t/t1092-sparse-checkout-compatibility.sh: test_expect_success 'mv directory from
     +		test_sparse_match git status --porcelain=v2
     +	done &&
     +
    ++	cat >folder1-full <<-EOF &&
    ++	rm ${SQ}folder1/0/0/0${SQ}
    ++	rm ${SQ}folder1/0/1${SQ}
    ++	rm ${SQ}folder1/a${SQ}
    ++	EOF
    ++
    ++	cat >folder1-sparse <<-EOF &&
    ++	rm ${SQ}folder1/${SQ}
    ++	EOF
    ++
     +	# test wildcard
     +	run_on_sparse git reset --hard &&
    ++	run_on_sparse git sparse-checkout reapply &&
     +	test_sparse_match test_must_fail git rm folder1/* &&
    -+	test_sparse_match git rm --sparse folder1/* &&
    ++	run_on_sparse git rm --sparse folder1/* &&
    ++	test_cmp folder1-full sparse-checkout-out &&
    ++	test_cmp folder1-sparse sparse-index-out &&
     +	test_sparse_match git status --porcelain=v2 &&
     +
     +	# test recursive rm
     +	run_on_sparse git reset --hard &&
    -+	test_sparse_match test_must_fail git rm folder1 &&
    -+	test_sparse_match git rm -r --sparse folder1 &&
    ++	run_on_sparse git sparse-checkout reapply &&
    ++	test_sparse_match test_must_fail git rm --sparse folder1 &&
    ++	run_on_sparse git rm --sparse -r folder1 &&
    ++	test_cmp folder1-full sparse-checkout-out &&
    ++	test_cmp folder1-sparse sparse-index-out &&
     +	test_sparse_match git status --porcelain=v2
     +'
     +
    -+test_expect_success 'sparse index is not expanded: rm' '
    ++test_expect_failure 'sparse index is not expanded: rm' '
     +	init_repos &&
     +
    -+	for file in deep/a deep/deeper1/a deep/deeper1/deepest/a
    -+	do
    -+		ensure_not_expanded rm $file
    -+	done &&
    ++	ensure_not_expanded rm deep/a &&
     +
    -+	# test in-cone wildcard not expand
    ++	# test in-cone wildcard
     +	git -C sparse-index reset --hard &&
     +	ensure_not_expanded rm deep/* &&
     +
    -+	# test recursive rm not expand
    ++	# test recursive rm
     +	git -C sparse-index reset --hard &&
     +	ensure_not_expanded rm -r deep
     +'
2:  a4be140bf0 ! 2:  f5534ddf92 pathspec.h: move pathspec_needs_expanded_index() from reset.c to here
    @@ Commit message
         the index needs to be expanded when the command is utilizing a pathspec
         rather than a literal path. Move it for reusability.
     
    +    Add a few items to the function so it can better serve its purpose as
    +    a standalone public function:
    +
    +    * Add a check in front so if the index is not sparse, return early since
    +      no expansion is needed.
    +
    +    * Add documentation to the function.
    +
         Signed-off-by: Shaoxuan Yuan <shaoxuan.yuan02@gmail.com>
     
      ## builtin/reset.c ##
    @@ pathspec.c: int match_pathspec_attrs(struct index_state *istate,
     +	char *skip_worktree_seen = NULL;
     +
     +	/*
    ++	 * If index is not sparse, no index expansion is needed.
    ++	 */
    ++	if (!istate->sparse_index)
    ++		return 0;
    ++
    ++	/*
     +	 * When using a magic pathspec, assume for the sake of simplicity that
     +	 * the index needs to be expanded to match all matchable files.
     +	 */
    @@ pathspec.h: int match_pathspec_attrs(struct index_state *istate,
      			 const char *name, int namelen,
      			 const struct pathspec_item *item);
      
    ++/*
    ++ * Determine whether a pathspec will match only entire index entries (non-sparse
    ++ * files and/or entire sparse directories). If the pathspec has the potential to
    ++ * match partial contents of a sparse directory, return 1 to indicate the index
    ++ * should be expanded to match the  appropriate index entries.
    ++ *
    ++ * For the sake of simplicity, always return 1 if using a more complex "magic"
    ++ * pathspec.
    ++ */
     +int pathspec_needs_expanded_index(struct index_state *istate,
     +				  const struct pathspec *pathspec);
     +
3:  dfc585f131 ! 3:  5921ac221e rm: expand the index only when necessary
    @@ Commit message
         environment, Git dies with "pathspec '<x>' did not match any files",
         mainly because it does not expand the index so nothing is matched.
     
    -    Expand the index when the pathspec needs an expanded index, i.e. the
    -    pathspec contains wildcard that may need a full-index or the pathspec
    -    is simply out-of-cone.
    +    Remove the `ensure_full_index()` method so `git-rm` does not always
    +    expand the index when the expansion is unnecessary, i.e. when
    +    <pathspec> does not have any possibilities to match anything outside
    +    of sparse-checkout definition.
    +
    +    Expand the index when the <pathspec> needs an expanded index, i.e. the
    +    <pathspec> contains wildcard that may need a full-index or the
    +    <pathspec> is simply outside of sparse-checkout definition.
     
         Signed-off-by: Shaoxuan Yuan <shaoxuan.yuan02@gmail.com>
     
    @@ builtin/rm.c: int cmd_rm(int argc, const char **argv, const char *prefix)
      
      	seen = xcalloc(pathspec.nr, 1);
      
    -+	if (the_index.sparse_index &&
    -+	    pathspec_needs_expanded_index(&the_index, &pathspec))
    +-	/* TODO: audit for interaction with sparse-index. */
    +-	ensure_full_index(&the_index);
    ++	if (pathspec_needs_expanded_index(&the_index, &pathspec))
     +		ensure_full_index(&the_index);
     +
      	for (i = 0; i < active_nr; i++) {
      		const struct cache_entry *ce = active_cache[i];
      
    -
    - ## t/t1092-sparse-checkout-compatibility.sh ##
    -@@ t/t1092-sparse-checkout-compatibility.sh: test_expect_success 'rm pathspec inside sparse definition' '
    - 	test_all_match git status --porcelain=v2
    - '
    - 
    --test_expect_failure 'rm pathspec outside sparse definition' '
    -+test_expect_success 'rm pathspec outside sparse definition' '
    - 	init_repos &&
    - 
    - 	for file in folder1/a folder1/0/1 folder1/0/0/0
5:  7d6fa3062a = 4:  8d6fc0674c t1092: normalize a behavioral difference of `git-rm` under sparse-index
4:  b01a786a72 ! 5:  e6ec4ca73e t/perf/p2000: add perf test for git-rm
    @@ Metadata
     Author: Shaoxuan Yuan <shaoxuan.yuan02@gmail.com>
     
      ## Commit message ##
    -    t/perf/p2000: add perf test for git-rm
    +    rm: integrate with sparse-index
     
         The `p2000` tests demonstrate a ~96% execution time reduction for
         'git rm' using a sparse index.
    @@ Commit message
     
         Signed-off-by: Shaoxuan Yuan <shaoxuan.yuan02@gmail.com>
     
    + ## builtin/rm.c ##
    +@@ builtin/rm.c: int cmd_rm(int argc, const char **argv, const char *prefix)
    + 	char *seen;
    + 
    + 	git_config(git_default_config, NULL);
    ++	if (the_repository->gitdir) {
    ++		prepare_repo_settings(the_repository);
    ++		the_repository->settings.command_requires_full_index = 0;
    ++	}
    + 
    + 	argc = parse_options(argc, argv, prefix, builtin_rm_options,
    + 			     builtin_rm_usage, 0);
    +
      ## t/perf/p2000-sparse-operations.sh ##
     @@ t/perf/p2000-sparse-operations.sh: test_perf_on_all git blame $SPARSE_CONE/f3/a
      test_perf_on_all git read-tree -mu HEAD
    @@ t/perf/p2000-sparse-operations.sh: test_perf_on_all git blame $SPARSE_CONE/f3/a
     +test_perf_on_all git rm -f $SPARSE_CONE/a
      
      test_done
    +
    + ## t/t1092-sparse-checkout-compatibility.sh ##
    +@@ t/t1092-sparse-checkout-compatibility.sh: test_expect_success 'rm pathspec inside sparse definition' '
    + 	test_all_match git status --porcelain=v2
    + '
    + 
    +-test_expect_failure 'rm pathspec outside sparse definition' '
    ++test_expect_success 'rm pathspec outside sparse definition' '
    + 	init_repos &&
    + 
    + 	for file in folder1/a folder1/0/1
    +@@ t/t1092-sparse-checkout-compatibility.sh: test_expect_failure 'rm pathspec outside sparse definition' '
    + 	test_sparse_match git status --porcelain=v2
    + '
    + 
    +-test_expect_failure 'sparse index is not expanded: rm' '
    ++test_expect_success 'sparse index is not expanded: rm' '
    + 	init_repos &&
    + 
    + 	ensure_not_expanded rm deep/a &&
```